### PR TITLE
use oauth2 client instead of token source, add context when init app

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ import (
 func main() {
   // Init App
   serviceAccount, _ := ioutil.ReadFile("service_account.json")
-  firApp, err := admin.InitializeApp(admin.AppOption{
+  firApp, err := admin.InitializeApp(context.Background(), admin.AppOption{
     ServiceAccount: serviceAccount,
     ProjectID: "YOUR_PROJECT_ID",
     DatabaseURL: "YOUR_DATABASE_URL",

--- a/app.go
+++ b/app.go
@@ -3,21 +3,20 @@ package admin
 import (
 	"context"
 	"crypto/rsa"
+	"net/http"
 
 	jwtgo "github.com/dgrijalva/jwt-go"
-	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
 )
 
 // App holds information about application configuration
 type App struct {
-	projectID      string
-	serviceAccount string
-	jwtConfig      *jwt.Config
-	privateKey     *rsa.PrivateKey
-	databaseURL    string
-	tokenSource    oauth2.TokenSource
+	projectID   string
+	jwtConfig   *jwt.Config
+	privateKey  *rsa.PrivateKey
+	databaseURL string
+	client      *http.Client
 }
 
 // AppOptions is the firebase app options for initialize app
@@ -28,7 +27,7 @@ type AppOptions struct {
 }
 
 // InitializeApp initializes firebase application with options
-func InitializeApp(options AppOptions) (*App, error) {
+func InitializeApp(ctx context.Context, options AppOptions) (*App, error) {
 	var err error
 
 	app := App{
@@ -45,9 +44,9 @@ func InitializeApp(options AppOptions) (*App, error) {
 		if err != nil {
 			return nil, err
 		}
-		app.tokenSource = app.jwtConfig.TokenSource(context.Background())
+		app.client = app.jwtConfig.Client(ctx)
 	} else {
-		app.tokenSource, err = google.DefaultTokenSource(context.Background(), scopes...)
+		app.client, err = google.DefaultClient(ctx, scopes...)
 		if err != nil {
 			return nil, err
 		}

--- a/app_test.go
+++ b/app_test.go
@@ -1,6 +1,7 @@
 package admin_test
 
 import (
+	"context"
 	"io/ioutil"
 
 	admin "github.com/acoshift/go-firebase-admin"
@@ -19,6 +20,6 @@ func initApp() *admin.App {
 	var c config
 	yaml.Unmarshal(bs, &c)
 
-	app, _ := admin.InitializeApp(admin.AppOptions(c))
+	app, _ := admin.InitializeApp(context.Background(), admin.AppOptions(c))
 	return app
 }

--- a/auth.go
+++ b/auth.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"golang.org/x/oauth2"
 	"google.golang.org/api/identitytoolkit/v3"
 	"google.golang.org/api/iterator"
 )
@@ -31,7 +30,7 @@ const (
 )
 
 func newAuth(app *App) *Auth {
-	gitClient, _ := identitytoolkit.New(oauth2.NewClient(context.Background(), app.tokenSource))
+	gitClient, _ := identitytoolkit.New(app.client)
 	return &Auth{
 		app:       app,
 		client:    gitClient.Relyingparty,

--- a/database.go
+++ b/database.go
@@ -2,18 +2,13 @@ package admin
 
 import (
 	"fmt"
-	"net"
-	"net/http"
 	_url "net/url"
 	_path "path"
-	"time"
 )
 
 // Database type
 type Database struct {
-	app       *App
-	transport *http.Transport
-	client    *http.Client
+	app *App
 }
 
 // ServerValue
@@ -24,18 +19,8 @@ var (
 )
 
 func newDatabase(app *App) *Database {
-	tr := &http.Transport{
-		IdleConnTimeout: time.Minute * 5,
-		MaxIdleConns:    20,
-		Dial: func(network, address string) (net.Conn, error) {
-			c, err := net.Dial(network, address)
-			return c, err
-		},
-	}
 	return &Database{
-		app:       app,
-		transport: tr,
-		client:    &http.Client{Transport: tr},
+		app: app,
 	}
 }
 

--- a/reference.go
+++ b/reference.go
@@ -95,16 +95,7 @@ func (ref *Reference) url() (*url.URL, error) {
 	if err != nil {
 		return nil, err
 	}
-	if ref.database.app.tokenSource == nil {
-		return u, nil
-	}
-	tk, err := ref.database.app.tokenSource.Token()
-	if err != nil {
-		return nil, err
-	}
-	token := tk.AccessToken
 	q := u.Query()
-	q.Add("access_token", token)
 	err = ref.buildQuery(q)
 	if err != nil {
 		return nil, err
@@ -124,7 +115,7 @@ func (ref *Reference) invokeRequest(method string, body io.Reader) ([]byte, erro
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	resp, err := ref.database.client.Do(req)
+	resp, err := ref.database.app.client.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
App:
- **Breaking Change** add context when init app
Auth & Database:
- Use OAuth2 Client instead of Token Source